### PR TITLE
Update de.json

### DIFF
--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -189,6 +189,9 @@
         "countryMirrorSuccess": "Erstellung eines eigenen Mirrorpools erfolgreich.",
         "countryMirrorFail": "Erstellung eines eigenen Mirrorpools fehlgeschlagen.",
         "fastestMirrorSuccess": "Schnellsten Mirror einrichten erfolgreich.",
-        "fastestMirrorFail": "Schnellsten Mirror einrichten fehlgeschlagen."
+        "fastestMirrorFail": "Schnellsten Mirror einrichten fehlgeschlagen.",
+        "uptime":"Betriebszeit",
+        "bootTime":"Bootzeit",
+        "disks":"Festplatten"
     }
 }


### PR DESCRIPTION
 Updated German translations with uptime, bootTime and disks. 

## Type of change

German Translations

Question: Does bootTime refer to amount of time the computer needs (in seconds?) to boot up?
What about componentTemp?

Thanks. 